### PR TITLE
Make animated plots code from Chapter 13 portable

### DIFF
--- a/pointsST.R
+++ b/pointsST.R
@@ -2,19 +2,19 @@
   ##################################################################
   ## Source code for the book: "Displaying time series, spatial and
   ## space-time data with R"
-  
+
   ## Copyright (C) 2013-2012 Oscar Perpiñán Lamigueiro
-  
+
   ## This program is free software you can redistribute it and/or modify
   ## it under the terms of the GNU General Public License as published
   ## by the Free Software Foundation; either version 2 of the License,
   ## or (at your option) any later version.
-   
+
   ## This program is distributed in the hope that it will be useful, but
   ## WITHOUT ANY WARRANTY; without even the implied warranty of
   ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
   ## General Public License for more details.
-   
+
   ## You should have received a copy of the GNU General Public License
   ## along with this program; if not, write to the Free Software
   ## Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
@@ -26,17 +26,17 @@
   ##################################################################
   ## Clone or download the repository and set the working directory
   ## with setwd to the folder where the repository is located.
-  
+
   library(lattice)
   library(latticeExtra)
-  
+
   myTheme <- custom.theme.2(pch=19, cex=0.7,
                             region=rev(brewer.pal(9, 'YlOrRd')),
                             symbol = brewer.pal(n=8, name = "Dark2"))
   myTheme$strip.background$col='transparent'
   myTheme$strip.shingle$col='transparent'
   myTheme$strip.border$col='transparent'
-  
+
   xscale.components.custom <- function(...){
       ans <- xscale.components.default(...)
       ans$top=FALSE
@@ -50,7 +50,7 @@
                  xscale.components = xscale.components.custom,
                  yscale.components = yscale.components.custom)
   defaultArgs <- lattice.options()$default.args
-  
+
   lattice.options(default.theme = myTheme,
                   default.args = modifyList(defaultArgs, myArgs))
 
@@ -59,7 +59,7 @@
 ##################################################################
 
   library(sp)
-  
+
   ## Spatial location of stations
   airStations <- read.csv2('data/airStations.csv')
   ## rownames are used as the ID of the Spatial object
@@ -68,18 +68,18 @@
   proj4string(airStations) <- CRS("+proj=longlat +ellps=WGS84")
   ## Measurements data
   airQuality <- read.csv2('data/airQuality.csv')
-  ## Only interested in NO2 
+  ## Only interested in NO2
   NO2 <- airQuality[airQuality$codParam==8, ]
 
   library(zoo)
   library(spacetime)
-  
+
   NO2$time <- with(NO2, ISOdate(year, month, day))
   NO2wide <- reshape(NO2[,c('codEst', 'dat', 'time')],
                      idvar='time', timevar='codEst',
                      direction='wide')
   NO2zoo <- zoo(NO2wide[,-1], NO2wide$time)
-  
+
   dats <- data.frame(vals=as.vector(t(NO2zoo)))
   NO2st <- STFDF(airStations, index(NO2zoo), dats)
 
@@ -89,7 +89,7 @@
 
 pdf(file="figs/NO2STxy.pdf")
   airPal <- colorRampPalette(c('springgreen1', 'sienna3', 'gray5'))(5)
-  
+
   stplot(NO2st[, 1:12], cuts=5, col.regions=airPal, edge.col='black')
 dev.off()
 
@@ -118,7 +118,7 @@ dev.off()
   ## values will be encoded as size of circles,
   ## so we need to scale them
   startVals <- start$vals/5000
-  
+
   nStations <- nrow(airStations)
   days <- index(NO2zoo)
   nDays <- length(days)
@@ -126,7 +126,7 @@ dev.off()
   duration <- nDays*.3
 
   library(grid)
-  
+
   ## Auxiliary panel function to display circles
   panel.circlesplot <- function(x, y, cex, col='gray',
                                 name='stationsCircles', ...){
@@ -134,7 +134,7 @@ dev.off()
               gp=gpar(fill=col, alpha=0.5),
               default.units='native', name=name)
   }
-  
+
   pStart <- spplot(start, panel=panel.circlesplot,
                    cex=startVals,
                    scales=list(draw=TRUE), auto.key=FALSE)
@@ -150,13 +150,13 @@ dev.off()
   color <- ifelse(isWeekend(days), 'blue', 'green')
   colorAnim <- animValue(rep(color, each=nStations),
                          id=rep(seq_len(nStations), nDays))
-  
+
   ## Intermediate sizes of the circles
   vals <- NO2st$vals/5000
   vals[is.na(vals)] <- 0
   radius <- animUnit(unit(vals, 'native'),
-                         id=rep(seq_len(nStations), nDays))                     
-  
+                         id=rep(seq_len(nStations), nDays))
+
   ## Animation of circles including sizes and colors
   grid.animate('stationsCircles',
                duration=duration,
@@ -176,7 +176,7 @@ dev.off()
   grid.rect(.5, 0.01, width=pbWidth, height=.01,
             just=c('center', 'bottom'),
             name='bgbar', gp=gpar(fill='gray'))
-  
+
   ## Width of the progress bar for each day
   dayWidth <- pbWidth/nDays
   ticks <- c(0, cumsum(as.numeric(diff(prettyDays)))*dayWidth) + .025
@@ -196,7 +196,12 @@ dev.off()
                onmouseover='document.rootElement.pauseAnimations()',
                onmouseout='document.rootElement.unpauseAnimations()')
 
-  grid.export('figs/NO2pb.svg')
+  if(.Platform$OS.type == "windows") {
+      grid.export('figs/NO2pb.svg',
+                  xmldecl = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
+  } else {
+        grid.export('figs/NO2pb.svg')
+  }
 
 ##################################################################
 ## Time reference: a time series plot
@@ -213,7 +218,7 @@ dev.off()
                       name='locator')
           grid.segments(0, 0, 0, 1, name='vLine')
       })
-  
+
   print(pStart, position=c(0, .2, 1, 1), more=TRUE)
   print(pTimeSeries, position=c(.1, 0, .9, .25))
 
@@ -221,22 +226,27 @@ dev.off()
                x=unit(as.numeric(index(NO2zoo)), 'native'),
                y=unit(as.numeric(NO2mean), 'native'),
                duration=duration, rep=TRUE)
-  
+
   xLine <- unit(index(NO2zoo), 'native')
-  
+
   grid.animate('vLine',
                x0=xLine, x1=xLine,
                duration=duration, rep=TRUE)
-  
+
   grid.animate('stationsCircles',
                duration=duration,
                r=radius,
                fill=colorAnim,
                rep=TRUE)
-  
+
   ## Pause animations when mouse is over the time series plot
   grid.garnish('timePlot', grep=TRUE,
                onmouseover='document.rootElement.pauseAnimations()',
                onmouseout='document.rootElement.unpauseAnimations()')
-  
-  grid.export('figs/vLine.svg')
+
+  if(.Platform$OS.type == "windows") {
+      grid.export('figs/vLine.svg',
+                  xmldecl = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
+  } else {
+      grid.export('figs/vLine.svg')
+  }


### PR DESCRIPTION
gridSVG's grid.export() function writes a header for the *.svg file
that it outputs, and will by default always specify an encoding other than
utf-8. That's a problem foor any plots that use symbols provided by R's
plotmath facilities, such as the two animated plots produced by
"pointsST.R". Both those plots use degree symbols in their tick labels
(coded as Unicode "DEGREE SIGN" symbols as documented at
https://www.stat.auckland.ac.nz/~paul/R/CM/AdobeSym.html ). The problem
can be sidestepped by explicitly passing in a header via grid.export()'s
xmldecl= argument, which is what I've done here.